### PR TITLE
Add minimal cmake-based build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,98 @@
+# Minimal CMake build for library, header, and *.pc - mostly to
+# simplify cross-compilation
+
+# Keeping in sync with autotools
+#   - review changes to `LIBOBJS` in `Makefile.in` and add the
+#     corresponding source files to `SOURCES` below
+#   - run `./config.h.cmake.in.gen` and add new platform checks[1]
+#     or third-party dependencies using `find_package`[2] or
+#     `FindPkgConfig`[3]
+#   - ensure new cflags/libs are added to `pkg-config` below
+#
+#[1] https://cmake.org/Wiki/CMake:How_To_Write_Platform_Checks
+#[2] https://cmake.org/cmake/help/latest/command/find_package.html
+#[3] https://cmake.org/cmake/help/latest/module/FindPkgConfig.html
+
+cmake_minimum_required(VERSION 3.1)
+project(mxml C)
+
+set(VERSION_MAJOR 2)
+set(VERSION_MINOR 11)
+set(SO_VERSION 1)
+set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}")
+set(VERSION_H "Mini-XML v${VERSION_MAJOR}.${VERSION_MINOR}")
+
+option(ENABLE_THREADS "Enable multi-threading support" ON)
+if(ENABLE_THREADS)
+    set(CMAKE_THREAD_PREFER_PTHREAD ON)
+    find_package(Threads REQUIRED)
+    set(HAVE_PTHREAD_H ON)
+endif()
+
+find_package(ZLIB)
+if(ZLIB_FOUND)
+    set(HAVE_ZLIB_H ON)
+endif()
+
+include(CheckFunctionExists)
+check_function_exists(snprintf  HAVE_SNPRINTF)
+check_function_exists(vasprintf HAVE_VASPRINTF)
+check_function_exists(vsnprintf HAVE_VSNPRINTF)
+check_function_exists(strdup    HAVE_STRDUP)
+check_function_exists(strlcat   HAVE_STRLCAT)
+check_function_exists(strlcpy   HAVE_STRLCPY)
+
+include(CheckTypeSize)
+check_type_size("long long" LONG_LONG)
+
+include_directories("${PROJECT_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+include_directories("${ZLIB_INCLUDE_DIRS}")
+
+set(SOURCES mxml-attr.c
+            mxml-entity.c
+            mxml-file.c
+            mxml-get.c
+            mxml-index.c
+            mxml-node.c
+            mxml-search.c
+            mxml-set.c
+            mxml-private.c
+            mxml-string.c
+)
+
+add_library(mxml ${SOURCES})
+set_target_properties(mxml PROPERTIES
+     SOVERSION ${SO_VERSION})
+
+if(WIN32 AND BUILD_SHARED_LIBS)
+    set(PC_LIB_NAME mxml-${SO_VERSION})
+    set_target_properties(mxml PROPERTIES
+         OUTPUT_NAME ${PC_LIB_NAME})
+else()
+    set(PC_LIB_NAME mxml)
+endif()
+
+if(ENABLE_THREADS)
+    target_link_libraries(mxml Threads::Threads)
+endif()
+target_link_libraries(mxml ZLIB::ZLIB)
+
+# pkg-config variables
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix "\$\{prefix\}")
+set(libdir "\$\{exec_prefix\}/lib")
+set(includedir "\$\{prefix\}/include")
+set(PC_LIBS "-L\$\{libdir\} -l${PC_LIB_NAME} ${ZLIB_LIBRARIES}")
+set(PTHREAD_LIBS ${CMAKE_THREAD_LIBS_INIT})
+set(PC_CFLAGS "-I\$\{includedir\} ${CMAKE_C_FLAGS} -I${ZLIB_INCLUDE_DIRS}")
+set(PTHREAD_FLAGS "")
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mxml.pc.in ${CMAKE_CURRENT_BINARY_DIR}/mxml.pc)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
+install(FILES "mxml.h" DESTINATION include)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/mxml.pc" DESTINATION lib/pkgconfig)
+install(TARGETS mxml
+        DESTINATION lib
+        RUNTIME DESTINATION bin)

--- a/config.h.cmake.in
+++ b/config.h.cmake.in
@@ -1,0 +1,109 @@
+/*
+ * Configuration file for Mini-XML, a small XML file parsing library.
+ *
+ * Copyright 2003-2017 by Michael R Sweet.
+ *
+ * These coded instructions, statements, and computer programs are the
+ * property of Michael R Sweet and are protected by Federal copyright
+ * law.  Distribution and use rights are outlined in the file "COPYING"
+ * which should have been included with this file.  If this file is
+ * missing or damaged, see the license at:
+ *
+ *     https://michaelrsweet.github.io/mxml
+ */
+
+/*
+ * Include necessary headers...
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <ctype.h>
+
+
+/*
+ * Version number...
+ */
+
+#define MXML_VERSION	"@VERSION_H@"
+
+
+/*
+ * Inline function support...
+ */
+
+#define inline
+
+
+/*
+ * Long long support...
+ */
+
+#cmakedefine HAVE_LONG_LONG
+
+
+/*
+ * Do we have <zlib.h>?
+ */
+
+#cmakedefine HAVE_ZLIB_H
+
+
+/*
+ * Do we have the *printf() functions?
+ */
+
+#cmakedefine HAVE_SNPRINTF
+#cmakedefine HAVE_VASPRINTF
+#cmakedefine HAVE_VSNPRINTF
+
+
+/*
+ * Do we have the strXXX() functions?
+ */
+
+#cmakedefine HAVE_STRDUP
+#cmakedefine HAVE_STRLCAT
+#cmakedefine HAVE_STRLCPY
+
+
+/*
+ * Do we have threading support?
+ */
+
+#cmakedefine HAVE_PTHREAD_H
+
+
+/*
+ * Define prototypes for string functions as needed...
+ */
+
+#  ifndef HAVE_STRDUP
+extern char	*_mxml_strdup(const char *);
+#    define strdup _mxml_strdup
+#  endif /* !HAVE_STRDUP */
+
+#  ifndef HAVE_STRLCAT
+extern size_t	_mxml_strlcat(char *, const char *, size_t);
+#    define strlcat _mxml_strlcat
+#  endif /* !HAVE_STRLCAT */
+
+#  ifndef HAVE_STRLCPY
+extern size_t	_mxml_strlcpy(char *, const char *, size_t);
+#    define strlcpy _mxml_strlcpy
+#  endif /* !HAVE_STRLCPY */
+
+extern char	*_mxml_strdupf(const char *, ...);
+extern char	*_mxml_vstrdupf(const char *, va_list);
+
+#  ifndef HAVE_SNPRINTF
+extern int	_mxml_snprintf(char *, size_t, const char *, ...);
+#    define snprintf _mxml_snprintf
+#  endif /* !HAVE_SNPRINTF */
+
+#  ifndef HAVE_VSNPRINTF
+extern int	_mxml_vsnprintf(char *, size_t, const char *, va_list);
+#    define vsnprintf _mxml_vsnprintf
+#  endif /* !HAVE_VSNPRINTF */

--- a/config.h.cmake.in.gen
+++ b/config.h.cmake.in.gen
@@ -1,0 +1,3 @@
+#! /bin/sh
+sed 's,\(.*MXML_VERSION[^"]*\).*,\1"@VERSION_H@",' config.h.in | \
+sed 's,#undef,#cmakedefine,g' > config.h.cmake.in


### PR DESCRIPTION
Allows support for cross-compiling both static and shared libs. Tested
using [MXE](mxe.cc) with:
`{i686-w64-mingw32,x86_64-w64-mingw32}.{static,shared}`

Closes #188