### PR TITLE
Fixed some memory leak issues.

### DIFF
--- a/mxml-file.c
+++ b/mxml-file.c
@@ -1368,9 +1368,9 @@ mxml_load_data(
     mxml_sax_cb_t   sax_cb,		/* I - SAX callback or MXML_NO_CALLBACK */
     void            *sax_data)		/* I - SAX user data */
 {
-  mxml_node_t	*node,			/* Current node */
-		*first,			/* First node added */
-		*parent;		/* Current parent node */
+   mxml_node_t	*node = NULL,		/* Current node */
+		*first = NULL,		/* First node added */
+		*parent = NULL;		/* Current parent node */
   int		line = 1,		/* Current line number */
 		ch,			/* Character from file */
 		whitespace;		/* Non-zero if whitespace seen */
@@ -1935,8 +1935,12 @@ mxml_load_data(
         {
           (*sax_cb)(node, MXML_SAX_ELEMENT_CLOSE, sax_data);
 
-          if (!mxmlRelease(node) && first == node)
-	    first = NULL;
+               if (!mxmlRelease(node))
+               {
+                   if(first == node)
+                       first = NULL;
+                   node = NULL;
+                }
         }
 
        /*
@@ -1983,6 +1987,7 @@ mxml_load_data(
 	  {
 	    mxml_error("Expected > but got '%c' instead for element <%s/> on line %d.", ch, buffer, line);
             mxmlDelete(node);
+            node = NULL;
             goto error;
 	  }
 
@@ -2015,8 +2020,12 @@ mxml_load_data(
         {
           (*sax_cb)(node, MXML_SAX_ELEMENT_CLOSE, sax_data);
 
-          if (!mxmlRelease(node) && first == node)
-            first = NULL;
+          if (!mxmlRelease(node))
+          {
+              if(first == node)
+                  first = NULL;
+              node = NULL;
+          }
         }
       }
 
@@ -2083,6 +2092,9 @@ mxml_load_data(
   */
 
   error:
+
+  if(node != NULL && node != first && node->parent == NULL)
+      mxmlDelete(node);
 
   mxmlDelete(first);
 

--- a/testmxml.c
+++ b/testmxml.c
@@ -660,8 +660,9 @@ main(int  argc,				/* I - Number of command-line args */
 
   memset(event_counts, 0, sizeof(event_counts));
 
+  mxml_node_t *root;
   if (argv[1][0] == '<')
-    mxmlSAXLoadString(NULL, argv[1], type_cb, sax_cb, NULL);
+    root = mxmlSAXLoadString(NULL, argv[1], type_cb, sax_cb, NULL);
   else if ((fp = fopen(argv[1], "rb")) == NULL)
   {
     perror(argv[1]);
@@ -673,10 +674,11 @@ main(int  argc,				/* I - Number of command-line args */
     * Read the file...
     */
 
-    mxmlSAXLoadFile(NULL, fp, type_cb, sax_cb, NULL);
+    root = mxmlSAXLoadFile(NULL, fp, type_cb, sax_cb, NULL);
 
     fclose(fp);
   }
+  mxmlRelease(root);
 
   if (!strcmp(argv[1], "test.xml"))
   {


### PR DESCRIPTION
There were several cases where the mxml_load_data() function, when it bailed out with an error, did not release the 'node' variable before returning.

Also fixed memory leak in the testmxml.c file, which cause some annoyance when building the library for fuzzing.