### PR TITLE
Improve detection of "long long int"

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -38,7 +38,7 @@
  * Long long support...
  */
 
-#undef HAVE_LONG_LONG
+#undef HAVE_LONG_LONG_INT
 
 
 /*

--- a/configure.ac
+++ b/configure.ac
@@ -130,23 +130,7 @@ AS_IF([test "x$use_vsnprintf" != xyes], [
 
 
 dnl Check for "long long" support...
-AC_CACHE_CHECK([for long long int], [ac_cv_c_long_long], [
-    AS_IF([test "$GCC" = yes], [
-	ac_cv_c_long_long=yes
-    ], [
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[
-	    long long int i;]])
-	], [
-	    ac_cv_c_long_long=yes
-	], [
-	    ac_cv_c_long_long=no
-	])
-    ])
-])
-
-AS_IF([test $ac_cv_c_long_long = yes], [
-    AC_DEFINE([HAVE_LONG_LONG], [Have the long long type?])
-])
+AC_TYPE_LONG_LONG_INT
 
 
 dnl Threading support

--- a/mxml-string.c
+++ b/mxml-string.c
@@ -374,11 +374,11 @@ _mxml_vsnprintf(char       *buffer,	/* O - Output buffer */
 	    if ((width + 2) > sizeof(temp))
 	      break;
 
-#ifdef HAVE_LONG_LONG
+#ifdef HAVE_LONG_LONG_INT
 	    if (size == 'L')
 	      sprintf(temp, tformat, va_arg(ap, long long));
 	    else
-#endif /* HAVE_LONG_LONG */
+#endif /* HAVE_LONG_LONG_INT */
 	    sprintf(temp, tformat, va_arg(ap, int));
 
             bytes += strlen(temp);

--- a/vcnet/config.h
+++ b/vcnet/config.h
@@ -77,7 +77,7 @@
  * Long long support...
  */
 
-#define HAVE_LONG_LONG 1
+#define HAVE_LONG_LONG_INT 1
 
 
 /*

--- a/xcode/config.h
+++ b/xcode/config.h
@@ -38,7 +38,7 @@
  * Long long support...
  */
 
-#define HAVE_LONG_LONG 1
+#define HAVE_LONG_LONG_INT 1
 
 
 /*


### PR DESCRIPTION
In my opinion, you can simplify a bit the configure script by using AC_TYPE_LONG_LONG_INT for detecting the support of long long type. The sources using HAVE_LONG_LONG just need to use HAVE_LONG_LONG_INT instead.