### PR TITLE
Split config.h.in in two files

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -10,17 +10,6 @@
  */
 
 /*
- * Include necessary headers...
- */
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdarg.h>
-#include <ctype.h>
-
-
-/*
  * Version number...
  */
 
@@ -67,33 +56,7 @@
 
 
 /*
- * Define prototypes for string functions as needed...
+ * Include common configuration file...
  */
 
-#  ifndef HAVE_STRDUP
-extern char	*_mxml_strdup(const char *);
-#    define strdup _mxml_strdup
-#  endif /* !HAVE_STRDUP */
-
-#  ifndef HAVE_STRLCAT
-extern size_t	_mxml_strlcat(char *, const char *, size_t);
-#    define strlcat _mxml_strlcat
-#  endif /* !HAVE_STRLCAT */
-
-#  ifndef HAVE_STRLCPY
-extern size_t	_mxml_strlcpy(char *, const char *, size_t);
-#    define strlcpy _mxml_strlcpy
-#  endif /* !HAVE_STRLCPY */
-
-extern char	*_mxml_strdupf(const char *, ...);
-extern char	*_mxml_vstrdupf(const char *, va_list);
-
-#  ifndef HAVE_SNPRINTF
-extern int	_mxml_snprintf(char *, size_t, const char *, ...);
-#    define snprintf _mxml_snprintf
-#  endif /* !HAVE_SNPRINTF */
-
-#  ifndef HAVE_VSNPRINTF
-extern int	_mxml_vsnprintf(char *, size_t, const char *, va_list);
-#    define vsnprintf _mxml_vsnprintf
-#  endif /* !HAVE_VSNPRINTF */
+ #include "mxml-config.h"

--- a/mxml-config.h
+++ b/mxml-config.h
@@ -1,0 +1,53 @@
+/*
+ * Configuration file for Mini-XML, a small XML file parsing library.
+ *
+ * https://www.msweet.org/mxml
+ *
+ * Copyright © 2003-2020 by Michael R Sweet.
+ *
+ * Licensed under Apache License v2.0.  See the file "LICENSE" for more
+ * information.
+ */
+
+/*
+ * Include necessary headers...
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <ctype.h>
+
+
+/*
+ * Define prototypes for string functions as needed...
+ */
+
+#  ifndef HAVE_STRDUP
+extern char	*_mxml_strdup(const char *);
+#    define strdup _mxml_strdup
+#  endif /* !HAVE_STRDUP */
+
+#  ifndef HAVE_STRLCAT
+extern size_t	_mxml_strlcat(char *, const char *, size_t);
+#    define strlcat _mxml_strlcat
+#  endif /* !HAVE_STRLCAT */
+
+#  ifndef HAVE_STRLCPY
+extern size_t	_mxml_strlcpy(char *, const char *, size_t);
+#    define strlcpy _mxml_strlcpy
+#  endif /* !HAVE_STRLCPY */
+
+extern char	*_mxml_strdupf(const char *, ...);
+extern char	*_mxml_vstrdupf(const char *, va_list);
+
+#  ifndef HAVE_SNPRINTF
+extern int	_mxml_snprintf(char *, size_t, const char *, ...);
+#    define snprintf _mxml_snprintf
+#  endif /* !HAVE_SNPRINTF */
+
+#  ifndef HAVE_VSNPRINTF
+extern int	_mxml_vsnprintf(char *, size_t, const char *, va_list);
+#    define vsnprintf _mxml_vsnprintf
+#  endif /* !HAVE_VSNPRINTF */


### PR DESCRIPTION
I would like to suggest to split config.h.in in two files:
- a config.h.in, which provides just the macros emitted by configure script.
- an mxml-config.h files, which provides headers inclusion and declaration of functions that won't be modified by autoconf.

So, basically nothing changes, but I'm implementing a complete CMake script for building MXML as a package for CYGWIN and this would be helpful to reduce the amount of duplicated code, at least in my opinion.