### PR TITLE
Memory controls have been added

### DIFF
--- a/mxml-entity.c
+++ b/mxml-entity.c
@@ -26,6 +26,8 @@ mxmlEntityAddCallback(
 {
   _mxml_global_t *global = _mxml_global();
 					/* Global data */
+  if (!global)
+    return (-1);
 
 
   if (global->num_entity_cbs < (int)(sizeof(global->entity_cbs) / sizeof(global->entity_cbs[0])))
@@ -87,6 +89,8 @@ mxmlEntityGetValue(const char *name)	/* I - Entity name */
   int		ch;			/* Character value */
   _mxml_global_t *global = _mxml_global();
 					/* Global data */
+  if (!global)
+    return (-1);
 
 
   for (i = 0; i < global->num_entity_cbs; i ++)
@@ -108,7 +112,8 @@ mxmlEntityRemoveCallback(
   int		i;			/* Looping var */
   _mxml_global_t *global = _mxml_global();
 					/* Global data */
-
+  if (!global)
+    return;
 
   for (i = 0; i < global->num_entity_cbs; i ++)
     if (cb == global->entity_cbs[i])

--- a/mxml-file.c
+++ b/mxml-file.c
@@ -263,6 +263,8 @@ mxmlSaveFd(mxml_node_t    *node,	/* I - Node to write */
   _mxml_fdbuf_t	buf;			/* File descriptor buffer */
   _mxml_global_t *global = _mxml_global();
 					/* Global data */
+  if (!global)
+    return (-1);
 
 
  /*
@@ -310,6 +312,8 @@ mxmlSaveFile(mxml_node_t    *node,	/* I - Node to write */
   int	col;				/* Final column */
   _mxml_global_t *global = _mxml_global();
 					/* Global data */
+  if (!global)
+    return (-1);
 
 
  /*
@@ -355,6 +359,8 @@ mxmlSaveString(mxml_node_t    *node,	/* I - Node to write */
   char	*ptr[2];			/* Pointers for putc_cb */
   _mxml_global_t *global = _mxml_global();
 					/* Global data */
+  if (!global)
+    return (-1);
 
 
  /*
@@ -523,6 +529,8 @@ mxmlSetCustomHandlers(
 {
   _mxml_global_t *global = _mxml_global();
 					/* Global data */
+  if (!global)
+    return;
 
 
   global->custom_load_cb = load;
@@ -539,6 +547,8 @@ mxmlSetErrorCallback(mxml_error_cb_t cb)/* I - Error callback function */
 {
   _mxml_global_t *global = _mxml_global();
 					/* Global data */
+  if (!global)
+    return;
 
 
   global->error_cb = cb;
@@ -558,6 +568,8 @@ mxmlSetWrapMargin(int column)		/* I - Column for wrapping, 0 to disable wrapping
 {
   _mxml_global_t *global = _mxml_global();
 					/* Global data */
+  if (!global)
+    return;
 
 
   global->wrap = column;
@@ -1459,6 +1471,11 @@ mxml_load_data(
 	    break;
 
 	case MXML_CUSTOM :
+	    if (!global)
+	    {
+	      return NULL;
+	    }
+
 	    if (global->custom_load_cb)
 	    {
 	     /*

--- a/mxml-index.c
+++ b/mxml-index.c
@@ -349,10 +349,7 @@ mxmlIndexNew(mxml_node_t *node,		/* I - XML node tree */
   {
     if (ind->num_nodes >= ind->alloc_nodes)
     {
-      if (!ind->alloc_nodes)
-        temp = malloc(64 * sizeof(mxml_node_t *));
-      else
-        temp = realloc(ind->nodes, (ind->alloc_nodes + 64) * sizeof(mxml_node_t *));
+      temp = realloc(ind->nodes, (ind->alloc_nodes + 64) * sizeof(mxml_node_t *));
 
       if (!temp)
       {
@@ -500,7 +497,7 @@ index_compare(mxml_index_t *ind,	/* I - Index */
               mxml_node_t  *second)	/* I - Second node */
 {
   int	diff;				/* Difference */
-
+  const char *str1 = NULL, *str2 = NULL;
 
  /*
   * Check the element name...
@@ -516,8 +513,16 @@ index_compare(mxml_index_t *ind,	/* I - Index */
 
   if (ind->attr)
   {
-    if ((diff = strcmp(mxmlElementGetAttr(first, ind->attr),
-                       mxmlElementGetAttr(second, ind->attr))) != 0)
+    str1 = mxmlElementGetAttr(first, ind->attr);
+    str2 = mxmlElementGetAttr(second, ind->attr);
+
+    if (!str1 && !str2)
+      return (0); /* both null */
+
+    if (!str1 || !str2)
+      return (str1 ? 1 : -1); /* one of them is null */
+
+    if ((diff = strcmp(str1, str2)) != 0)
       return (diff);
   }
 
@@ -540,7 +545,7 @@ index_find(mxml_index_t *ind,		/* I - Index */
            mxml_node_t  *node)		/* I - Node */
 {
   int	diff;				/* Difference */
-
+  const char *str = NULL;
 
  /*
   * Check the element name...
@@ -558,7 +563,12 @@ index_find(mxml_index_t *ind,		/* I - Index */
 
   if (value)
   {
-    if ((diff = strcmp(value, mxmlElementGetAttr(node, ind->attr))) != 0)
+    str = mxmlElementGetAttr(node, ind->attr);
+
+    if (!str)
+      return 1;
+
+    if ((diff = strcmp(value, str)) != 0)
       return (diff);
   }
 

--- a/mxml-private.c
+++ b/mxml-private.c
@@ -61,7 +61,7 @@ mxml_error(const char *format,		/* I - Printf-style format string */
   * Range check input...
   */
 
-  if (!format)
+  if (!format || !global)
     return;
 
  /*
@@ -186,7 +186,9 @@ _mxml_global(void)
 
   if ((global = (_mxml_global_t *)pthread_getspecific(_mxml_key)) == NULL)
   {
-    global = (_mxml_global_t *)calloc(1, sizeof(_mxml_global_t));
+    if ((global = (_mxml_global_t *)calloc(1, sizeof(_mxml_global_t))) == NULL)
+      return NULL;
+
     pthread_setspecific(_mxml_key, global);
 
     global->num_entity_cbs = 1;
@@ -270,7 +272,8 @@ _mxml_global(void)
 
   if ((global = (_mxml_global_t *)TlsGetValue(_mxml_tls_index)) == NULL)
   {
-    global = (_mxml_global_t *)calloc(1, sizeof(_mxml_global_t));
+    if ((global = (_mxml_global_t *)calloc(1, sizeof(_mxml_global_t))) == NULL)
+      return NULL;
 
     global->num_entity_cbs = 1;
     global->entity_cbs[0]  = _mxml_entity_cb;

--- a/mxml-string.c
+++ b/mxml-string.c
@@ -85,7 +85,7 @@ _mxml_strdupf(const char *format,	/* I - Printf-style format string */
               ...)			/* I - Additional arguments as needed */
 {
   va_list	ap;			/* Pointer to additional arguments */
-  char		*s;			/* Pointer to formatted string */
+  char		*s = NULL;		/* Pointer to formatted string */
 
 
  /*
@@ -508,7 +508,7 @@ _mxml_vstrdupf(const char *format,	/* I - Printf-style format string */
                va_list    ap)		/* I - Pointer to additional arguments */
 {
 #ifdef HAVE_VASPRINTF
-  char		*s;			/* String */
+  char		*s = NULL;		/* String */
 
   if (vasprintf(&s, format, ap) < 0)
     s = NULL;


### PR DESCRIPTION
I made a small change besides the memory controls.

```
if (!ind->alloc_nodes)
  temp = malloc(64 * sizeof(mxml_node_t *));
else
  temp = realloc(ind->nodes, (ind->alloc_nodes + 64) * sizeof(mxml_node_t *));
```
Since the _ind_ is allocated with the calloc, _ind->nodes_ contains NULL and _ind->alloc_nodes_ contains 0. realloc works as malloc if the first parameter is NULL. Your size is also same for both. (_ind->alloc_nodes_=0 + 64 = 64)

So we can rid of the if statement and we can use realloc for both case.
