### PR TITLE
fix some warnings (and maybe a bug?)

### DIFF
--- a/mxml-file.c
+++ b/mxml-file.c
@@ -1473,8 +1473,8 @@ mxml_load_data(
 		mxmlDelete(node);
 		node = NULL;
 	      }
-	      break;
 	    }
+	    break;
 
         default : /* Ignore... */
 	    node = NULL;

--- a/mxml-file.c
+++ b/mxml-file.c
@@ -3017,8 +3017,8 @@ mxml_write_node(mxml_node_t     *node,	/* I - Node to write */
 	      col = (int)strlen(newline);
 
 	    free(data);
-	    break;
 	  }
+	  break;
 
       default : /* Should never happen */
 	  return (-1);

--- a/mxml-search.c
+++ b/mxml-search.c
@@ -160,7 +160,7 @@ mxmlFindPath(mxml_node_t *top,		/* I - Top node */
     if ((pathsep = strchr(path, '/')) == NULL)
       pathsep = path + strlen(path);
 
-    if (pathsep == path || (pathsep - path) >= sizeof(element))
+    if (pathsep == path || (pathsep - path) >= (long int)sizeof(element))
       return (NULL);
 
     memcpy(element, path, pathsep - path);

--- a/mxml-string.c
+++ b/mxml-string.c
@@ -341,7 +341,7 @@ _mxml_vsnprintf(char       *buffer,	/* O - Output buffer */
 	case 'e' :
 	case 'f' :
 	case 'g' :
-	    if ((width + 2) > sizeof(temp))
+	    if ((width + 2) > (int)sizeof(temp))
 	      break;
 
 	    sprintf(temp, tformat, va_arg(ap, double));
@@ -371,7 +371,7 @@ _mxml_vsnprintf(char       *buffer,	/* O - Output buffer */
 	case 'o' :
 	case 'u' :
 	case 'x' :
-	    if ((width + 2) > sizeof(temp))
+	    if ((width + 2) > (int)sizeof(temp))
 	      break;
 
 #ifdef HAVE_LONG_LONG_INT
@@ -399,7 +399,7 @@ _mxml_vsnprintf(char       *buffer,	/* O - Output buffer */
 	    break;
 
 	case 'p' : /* Pointer value */
-	    if ((width + 2) > sizeof(temp))
+	    if ((width + 2) > (int)sizeof(temp))
 	      break;
 
 	    sprintf(temp, tformat, va_arg(ap, void *));

--- a/mxml-string.c
+++ b/mxml-string.c
@@ -202,7 +202,9 @@ _mxml_vsnprintf(char       *buffer,	/* O - Output buffer */
   char		*bufptr,		/* Pointer to position in buffer */
 		*bufend,		/* Pointer to end of buffer */
 		sign,			/* Sign of format width */
+#ifdef HAVE_LONG_LONG_INT
 		size,			/* Size character (h, l, L) */
+#endif
 		type;			/* Format type character */
   int		width,			/* Width of field */
 		prec;			/* Number of characters of precision */
@@ -307,7 +309,9 @@ _mxml_vsnprintf(char       *buffer,	/* O - Output buffer */
 
       if (*format == 'l' && format[1] == 'l')
       {
+#ifdef HAVE_LONG_LONG_INT
         size = 'L';
+#endif
 
 	if (tptr < (tformat + sizeof(tformat) - 2))
 	{
@@ -322,7 +326,9 @@ _mxml_vsnprintf(char       *buffer,	/* O - Output buffer */
 	if (tptr < (tformat + sizeof(tformat) - 1))
 	  *tptr++ = *format;
 
+#ifdef HAVE_LONG_LONG_INT
         size = *format++;
+#endif
       }
 
       if (!*format)


### PR DESCRIPTION
Changes:
casted some sizeof() to prevent signed/unsigned comparison
moved break; outside the if they were at two switch/case statements, not sure if those fallthroughs were intended tho.
at _mxml_vsnprintf, put the char *size variable inside an #ifdef because it's only used if that condition is met