### PR TITLE
Error reporting doesn't allow for NULL options

### DIFF
--- a/mxml-options.c
+++ b/mxml-options.c
@@ -538,7 +538,7 @@ _mxml_error(mxml_options_t *options,	// I - Load/save options
   va_end(ap);
 
   // And then display the error message...
-  if (options->error_cb)
+  if (options && options->error_cb)
     (options->error_cb)(options->error_cbdata, s);
   else
     fprintf(stderr, "%s\n", s);


### PR DESCRIPTION
If the passed-in options are null, a segment error occurs when trying to access a member with a null pointer.
I found this problem when I was using mxmlLoadFilename(NULL, NULL, pFilePath); to load an xml file, which was not in the correct format, and it reported a segment error directly and did not have any hint of an error message.