### PR TITLE
Mxml load buffer

### DIFF
--- a/doc/mxml.3
+++ b/doc/mxml.3
@@ -74,20 +74,22 @@ function:
     fclose(fp);
 .fi
 .PP
-The "mxmlLoadString()", "mxmlSaveAllocString()", and
+The "mxmlLoadString()", "mxmlLoadBuffer()", "mxmlSaveAllocString()", and
 "mxmlSaveString()" functions load XML node trees from and save
 XML node trees to strings:
 .nf
 
-    char buffer[8192];
+    const char *input;
+    char output[8192];
     char *ptr;
+    mxml_options_t *options;
     mxml_node_t *tree;
 
     ...
-    tree = mxmlLoadString(NULL, buffer, MXML_NO_CALLBACK);
+    tree = mxmlLoadString(NULL, options, input);
 
     ...
-    mxmlSaveString(tree, buffer, sizeof(buffer),
+    mxmlSaveString(tree, output, sizeof(output),
                    MXML_NO_CALLBACK);
 
     ...
@@ -837,6 +839,26 @@ This function loads the string into an XML node tree.  The nodes in the
 specified file are added to the specified node \fBtop\fR - if \fBNULL\fR the XML file
 MUST be well-formed with a single parent processing instruction node like
 \fB<?xml version="1.0"?>\fR at the start of the file.
+.PP
+Load options are provides via the \fBoptions\fR argument.  If \fBNULL\fR, all values
+will be loaded into \fBMXML_TYPE_TEXT\fR nodes.  Use the \fImxmlOptionsNew\fR
+function to create options when loading XML data.
+.SS mxmlLoadString
+Load a string into an XML node tree.
+.PP
+.nf
+mxml_node_t * mxmlLoadBuffer (
+    mxml_node_t *top,
+    mxml_options_t *options,
+    const char *buffer,
+    size_t buflen
+);
+.fi
+.PP
+This function loads up to buflen bytes from the buffer into an XML node tree.
+The nodes in the specified file are added to the specified node \fBtop\fR - if
+\fBNULL\fR the XML file MUST be well-formed with a single parent processing
+instruction node like \fB<?xml version="1.0"?>\fR at the start of the file.
 .PP
 Load options are provides via the \fBoptions\fR argument.  If \fBNULL\fR, all values
 will be loaded into \fBMXML_TYPE_TEXT\fR nodes.  Use the \fImxmlOptionsNew\fR

--- a/mxml-file.c
+++ b/mxml-file.c
@@ -207,6 +207,42 @@ mxmlLoadIO(
 
 
 //
+// 'mxmlLoadBuffer()' - Load a buffer into an XML node tree.
+//
+// This function loads up to buflen bytes from the buffer into an XML node tree.
+// The nodes in the specified file are added to the specified node `top` - if
+// `NULL` the XML file MUST be well-formed with a single parent processing
+// instruction node like `<?xml version="1.0"?>` at the start of the file.
+//
+// Load options are provides via the `options` argument.  If `NULL`, all values
+// will be loaded into `MXML_TYPE_TEXT` nodes.  Use the @link mxmlOptionsNew@
+// function to create options when loading XML data.
+//
+mxml_node_t *				// O - First node or `NULL` if the string has errors.
+mxmlLoadBuffer(
+    mxml_node_t    *top,		// I - Top node
+    mxml_options_t *options,		// I - Options
+    const char     *buffer,		// I - Buffer to load
+    size_t         buflen)		// I - Buffer to load
+{
+  _mxml_stringbuf_t	sb;		// String buffer
+
+  // Range check input...
+  if (!buffer || !buflen)
+    return (NULL);
+
+  // Setup string buffer...
+  sb.buffer   = (char *)buffer;
+  sb.bufptr   = (char *)buffer;
+  sb.bufsize  = buflen;
+  sb.bufalloc = false;
+
+  // Read the XML data...
+  return (mxml_load_data(top, options, (mxml_io_cb_t)mxml_read_cb_string, &sb));
+}
+
+
+//
 // 'mxmlLoadString()' - Load a string into an XML node tree.
 //
 // This function loads the string into an XML node tree.  The nodes in the
@@ -225,23 +261,8 @@ mxmlLoadString(
     mxml_options_t *options,		// I - Options
     const char     *s)			// I - String to load
 {
-  _mxml_stringbuf_t	sb;		// String buffer
-
-
-  // Range check input...
-  if (!s)
-    return (NULL);
-
-  // Setup string buffer...
-  sb.buffer   = (char *)s;
-  sb.bufptr   = (char *)s;
-  sb.bufsize  = strlen(s);
-  sb.bufalloc = false;
-
-  // Read the XML data...
-  return (mxml_load_data(top, options, (mxml_io_cb_t)mxml_read_cb_string, &sb));
+  return mxmlLoadBuffer(top, options, s, s ? strlen(s) : 0);
 }
-
 
 //
 // 'mxmlSaveAllocString()' - Save an XML tree to an allocated string.

--- a/mxml.h
+++ b/mxml.h
@@ -180,6 +180,7 @@ extern mxml_node_t	*mxmlLoadFile(mxml_node_t *top, mxml_options_t *options, FILE
 extern mxml_node_t	*mxmlLoadFilename(mxml_node_t *top, mxml_options_t *options, const char *filename);
 extern mxml_node_t	*mxmlLoadIO(mxml_node_t *top, mxml_options_t *options, mxml_io_cb_t io_cb, void *io_cbdata);
 extern mxml_node_t	*mxmlLoadString(mxml_node_t *top, mxml_options_t *options, const char *s);
+extern mxml_node_t	*mxmlLoadBuffer(mxml_node_t *top, mxml_options_t *options, const char *buffer, size_t buflen);
 
 extern void		mxmlOptionsDelete(mxml_options_t *options);
 extern mxml_options_t	*mxmlOptionsNew(void);


### PR DESCRIPTION
Hello,

I'm proposing the addition of `mxmlLoadBuffer`, a function that allows to parse a generic buffer, which might not be null terminated. Possible use case: a memory mapped file.

The regular `mxmlLoadString` becomes a specialization.

I updated the manpage, but then I started wondering if the documents are auto-generated. If not, I can update the other documents too.