### PR TITLE
C4267 conversion from 'size_t' to 'int'

### DIFF
--- a/mxml-attr.c
+++ b/mxml-attr.c
@@ -232,7 +232,7 @@ mxml_set_attr(mxml_node_t *node,	// I - Element node
               const char  *name,	// I - Attribute name
               char        *value)	// I - Attribute value
 {
-  int		i;			// Looping var
+  size_t	i;			// Looping var
   _mxml_attr_t	*attr;			// New attribute
 
 

--- a/mxml-file.c
+++ b/mxml-file.c
@@ -1733,7 +1733,7 @@ mxml_read_cb_fd(int    *fd,		// I - File descriptor
   int		rbytes;			// Bytes read
 
 
-  rbytes = read(*fd, buffer, bytes);
+  rbytes = read(*fd, buffer, (unsigned int)bytes);
 
 #else
   ssize_t	rbytes;			// Bytes read
@@ -1894,7 +1894,7 @@ mxml_io_cb_fd(int    *fd,		// I - File descriptor
   ssize_t	wbytes;			// Bytes written
 
 
-  while ((wbytes = write(*fd, buffer, bytes)) < 0)
+  while ((wbytes = write(*fd, buffer, (unsigned int)bytes)) < 0)
   {
     if (errno != EINTR && errno != EAGAIN)
       break;

--- a/mxml-index.c
+++ b/mxml-index.c
@@ -18,7 +18,7 @@
 
 static int	index_compare(mxml_index_t *ind, mxml_node_t *first, mxml_node_t *second);
 static int	index_find(mxml_index_t *ind, const char *element, const char *value, mxml_node_t *node);
-static void	index_sort(mxml_index_t *ind, int left, int right);
+static void	index_sort(mxml_index_t *ind, size_t left, size_t right);
 
 
 //
@@ -265,7 +265,7 @@ mxmlIndexNew(mxml_node_t *node,		// I - XML node tree
 
   // Sort nodes based upon the search criteria...
   if (ind->num_nodes > 1)
-    index_sort(ind, 0, ind->num_nodes - 1);
+    (ind, 0, ind->num_nodes - 1);
 
   // Return the new index...
   return (ind);
@@ -369,12 +369,12 @@ index_find(mxml_index_t *ind,		// I - Index
 
 static void
 index_sort(mxml_index_t *ind,		// I - Index to sort
-           int          left,		// I - Left node in partition
-	   int          right)		// I - Right node in partition
+           size_t        left,		// I - Left node in partition
+	   size_t        right)		// I - Right node in partition
 {
   mxml_node_t	*pivot,			// Pivot node
 		*temp;			// Swap node
-  int		templ,			// Temporary left node
+  size_t        templ,			// Temporary left node
 		tempr;			// Temporary right node
 
 

--- a/mxml-index.c
+++ b/mxml-index.c
@@ -80,7 +80,7 @@ mxmlIndexFind(mxml_index_t *ind,	// I - Index to search
               const char   *element,	// I - Element name to find, if any
 	      const char   *value)	// I - Attribute value, if any
 {
-  int		diff,			// Difference between names
+  size_t	diff,			// Difference between names
 		current,		// Current entity in search
 		first,			// First entity in search
 		last;			// Last entity in search

--- a/mxml-index.c
+++ b/mxml-index.c
@@ -265,7 +265,7 @@ mxmlIndexNew(mxml_node_t *node,		// I - XML node tree
 
   // Sort nodes based upon the search criteria...
   if (ind->num_nodes > 1)
-    (ind, 0, ind->num_nodes - 1);
+    index_sort(ind, 0, ind->num_nodes - 1);
 
   // Return the new index...
   return (ind);

--- a/mxml-node.c
+++ b/mxml-node.c
@@ -801,7 +801,7 @@ mxmlNewXML(const char *version)		// I - Version number to use
 // is deleted via @link mxmlDelete@.
 //
 
-int					// O - New reference count
+size_t					// O - New reference count
 mxmlRelease(mxml_node_t *node)		// I - Node
 {
   if (node)
@@ -827,7 +827,7 @@ mxmlRelease(mxml_node_t *node)		// I - Node
 // 'mxmlRetain()' - Retain a node.
 //
 
-int					// O - New reference count
+size_t					// O - New reference count
 mxmlRetain(mxml_node_t *node)		// I - Node
 {
   if (node)

--- a/mxml.h
+++ b/mxml.h
@@ -210,9 +210,9 @@ extern mxml_node_t	*mxmlNewText(mxml_node_t *parent, bool whitespace, const char
 extern mxml_node_t	*mxmlNewTextf(mxml_node_t *parent, bool whitespace, const char *format, ...) MXML_FORMAT(3,4);
 extern mxml_node_t	*mxmlNewXML(const char *version);
 
-extern int		mxmlRelease(mxml_node_t *node);
+extern size_t		mxmlRelease(mxml_node_t *node);
 extern void		mxmlRemove(mxml_node_t *node);
-extern int		mxmlRetain(mxml_node_t *node);
+extern size_t		mxmlRetain(mxml_node_t *node);
 
 extern char		*mxmlSaveAllocString(mxml_node_t *node, mxml_options_t *options);
 extern bool		mxmlSaveFd(mxml_node_t *node, mxml_options_t *options, int fd);


### PR DESCRIPTION
This PR updates some types to avoid warnings for C4267: conversion from 'size_t' to 'int' when compiling with MSVC